### PR TITLE
Remove redis and fnct dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,23 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 
 [[package]]
-name = "arc-swap"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
-
-[[package]]
-name = "async-trait"
-version = "0.1.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,20 +217,6 @@ name = "cobs"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
 
 [[package]]
 name = "config"
@@ -442,20 +411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "fnct"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4264a92a1d8fd9e5f6f19aad6cdcfc7c4906aad6d64e0ccc37f339272c328366"
-dependencies = [
- "async-trait",
- "postcard",
- "redis",
- "serde",
- "sha2",
- "thiserror",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,7 +433,6 @@ checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -500,17 +454,6 @@ name = "futures-core"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -547,7 +490,6 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1007,29 +949,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"
@@ -1457,29 +1380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902a69d09078829137b4a5d9d082e0490393537badd7c91a3d69d14639e115f"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "combine",
- "futures",
- "futures-util",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "tokio",
- "tokio-retry",
- "tokio-util",
- "url",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,7 +1574,6 @@ version = "0.2.2"
 dependencies = [
  "anyhow",
  "config",
- "fnct",
  "indoc",
  "key-rwlock",
  "once_cell",
@@ -1684,7 +1583,6 @@ dependencies = [
  "postcard",
  "prometheus",
  "proptest",
- "redis",
  "regex",
  "sandkasten-client",
  "serde",
@@ -2008,17 +1906,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 [dependencies]
 anyhow = { version = "1.0.83", default-features = false, features = ["std"] }
 config = { version = "0.14.0", default-features = false, features = ["toml", "json"] }
-fnct = { version = "0.6.5", default-features = false }
 key-rwlock = { version = "0.1.2", default-features = false }
 once_cell = { version = "1.19.0", default-features = false }
 poem = { version = "3.0.4", default-features = false, features = ["server", "anyhow"] }
@@ -24,7 +23,6 @@ poem-ext = { version = "0.12.0", default-features = false, features = ["shield"]
 poem-openapi = { version = "5.0.3", default-features = false, features = ["swagger-ui", "redoc", "uuid"] }
 postcard = { version = "1.0.10", default-features = false, features = ["use-std"] }
 prometheus = { version = "0.13.4", default-features = false }
-redis = { version = "0.26.1", default-features = false, features = ["tokio-comp", "connection-manager"] }
 regex = "1.10.6"
 sandkasten-client = { path = "client", default-features = false, features = ["poem-openapi"] }
 serde.workspace = true

--- a/README.md
+++ b/README.md
@@ -177,13 +177,6 @@ remove packages later, but you need to restart Sandkasten after doing so. See
 [`nix profile --help`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-profile.html)
 for details.
 
-#### Setup Redis
-Sandkasten uses [Redis](https://redis.io/) for caching. To start a redis server for development,
-simply run `redis-server` in the development shell. Otherwise, if you already have a redis server
-running somewhere, that you would like to use instead, set the environment variable `REDIS_URL`
-to the url of your redis server (see https://docs.rs/redis/latest/redis/#connection-parameters for
-details).
-
 #### Start the application
 In the development shell you can just use `cargo run` to start Sandkasten.
 

--- a/client/src/schemas/environments.rs
+++ b/client/src/schemas/environments.rs
@@ -41,7 +41,7 @@ pub struct Environment {
 pub struct ListEnvironmentsResponse(pub HashMap<String, Environment>);
 
 /// The base resource usage of an environment.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "poem-openapi", derive(Object))]
 pub struct BaseResourceUsage {
     /// The base resource usage of the build step.
@@ -51,7 +51,7 @@ pub struct BaseResourceUsage {
 }
 
 /// The base resource usage of the run step.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "poem-openapi", derive(Object))]
 pub struct RunResourceUsage {
     /// The number of **milliseconds** the process ran.
@@ -61,7 +61,7 @@ pub struct RunResourceUsage {
 }
 
 /// Accumulated benchmark results.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 #[cfg_attr(feature = "poem-openapi", derive(Object))]
 pub struct BenchmarkResult {
     /// The minimum of the measured values.

--- a/client/src/schemas/programs.rs
+++ b/client/src/schemas/programs.rs
@@ -207,7 +207,7 @@ pub enum RunError {
 }
 
 /// The amount of resources a process used.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[cfg_attr(feature = "poem-openapi", derive(Object))]
 pub struct ResourceUsage {
     /// The number of **milliseconds** the process ran.

--- a/config.toml
+++ b/config.toml
@@ -2,9 +2,6 @@ host = "0.0.0.0"
 port = 8000
 server = "/"
 
-redis_url = "redis://127.0.0.1:6379/0"
-cache_ttl = 3600
-
 enable_metrics = false
 
 programs_dir = "/programs"
@@ -17,6 +14,7 @@ max_concurrent_jobs = 16
 
 base_resource_usage_runs = 20
 base_resource_usage_permits = 16
+base_resource_usage_cache_ttl = 3600  # seconds
 
 use_cgroup = true
 # nsjail_path = ...

--- a/nix/dev/shell.nix
+++ b/nix/dev/shell.nix
@@ -74,8 +74,6 @@
   test-script = pkgs.writeShellScript "integration-tests.sh" ''
     export PROPTEST_CASES=''${1:-256}
     rm -rf programs jobs
-    echo 'save ""' | ${pkgs.redis}/bin/redis-server - &
-    redis_pid=$!
     RUST_LOG=info,poem::middleware::tracing_mw=off RUN_LIMITS__TIME=20 cargo llvm-cov run --lcov --output-path lcov-server.info --release --locked -F test_api &
     pid=$!
     while ! ${pkgs.curl}/bin/curl -so/dev/null localhost:8000; do
@@ -85,7 +83,6 @@
     out=$?
     ${pkgs.curl}/bin/curl -X POST localhost:8000/test/exit
     wait $pid
-    kill $redis_pid
     ${pkgs.lcov}/bin/lcov -a lcov-server.info -a lcov-tests.info -o lcov.info
     ${pkgs.gnugrep}/bin/grep -E -o '^cc [0-9a-f]{64}' tests/proptests.proptest-regressions
     exit $out
@@ -114,7 +111,7 @@
   };
 in {
   default = pkgs.mkShell ({
-      packages = [pkgs.cargo-llvm-cov pkgs.lcov pkgs.redis self.packages.${pkgs.system}.time scripts];
+      packages = [pkgs.cargo-llvm-cov pkgs.lcov self.packages.${pkgs.system}.time scripts];
       RUST_LOG = "info,sandkasten=trace,difft=off";
     }
     // test-env);

--- a/nix/nixos/module.nix
+++ b/nix/nixos/module.nix
@@ -21,10 +21,6 @@ in
           type = types.anything;
           default = _: [];
         };
-        redis = mkOption {
-          type = types.bool;
-          default = true;
-        };
         settings = mkOption {
           type = types.attrs;
           default = {};
@@ -42,26 +38,16 @@ in
             OOMPolicy = lib.mkDefault "continue";
           };
           environment = let
-            opts =
-              {
-                nsjail_path = "${pkgs.nsjail}/bin/nsjail";
-                time_path = "${self.packages.${pkgs.system}.time}/bin/time";
-                environments_path = ["${self.packages.${pkgs.system}.packages.combined cfg.environments}/share/sandkasten/packages"];
-                programs_dir = "/var/lib/sandkasten/programs";
-                jobs_dir = "/tmp/sandkasten/jobs";
-                base_resource_usage_permits = (conf // cfg.settings).max_concurrent_jobs;
-              }
-              // lib.optionalAttrs cfg.redis {
-                redis_url = "redis+unix:///${config.services.redis.servers.sandkasten.unixSocket}";
-              };
+            opts = {
+              nsjail_path = "${pkgs.nsjail}/bin/nsjail";
+              time_path = "${self.packages.${pkgs.system}.time}/bin/time";
+              environments_path = ["${self.packages.${pkgs.system}.packages.combined cfg.environments}/share/sandkasten/packages"];
+              programs_dir = "/var/lib/sandkasten/programs";
+              jobs_dir = "/tmp/sandkasten/jobs";
+              base_resource_usage_permits = (conf // cfg.settings).max_concurrent_jobs;
+            };
           in {
             CONFIG_PATH = pkgs.writeText "sandkasten-config.json" (builtins.toJSON (builtins.foldl' lib.recursiveUpdate {} [conf opts cfg.settings]));
-          };
-        };
-        services.redis = mkIf cfg.redis {
-          servers.sandkasten = {
-            enable = true;
-            save = [];
           };
         };
       };

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,6 @@ use config::{Environment, File};
 use sandkasten_client::schemas::programs::Limits;
 use serde::{Deserialize, Deserializer};
 use tracing::info;
-use url::Url;
 
 pub fn load() -> Result<Config, anyhow::Error> {
     let path = env::var("CONFIG_PATH").unwrap_or("config.toml".to_owned());
@@ -42,11 +41,6 @@ pub struct Config {
     /// a reverse proxy.
     pub server: String,
 
-    /// The url of the redis server (see https://docs.rs/redis/latest/redis/#connection-parameters).
-    pub redis_url: Url,
-    /// The default time to live for cache entries in seconds.
-    pub cache_ttl: u64,
-
     /// Whether to expose Prometheus metrics on `/metrics`.
     pub enable_metrics: bool,
 
@@ -76,6 +70,8 @@ pub struct Config {
     /// set to the value of `max_concurrent_jobs`, no other jobs can run at the
     /// same time.
     pub base_resource_usage_permits: u32,
+    /// The time to live for base resource usage cache entries in seconds.
+    pub base_resource_usage_cache_ttl: u64,
 
     /// Whether to use cgroup to set resource limits where possible. It is
     /// strongly recommended to set this to true in production environments!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 #![forbid(unsafe_code)]
 #![warn(clippy::dbg_macro, clippy::use_debug, clippy::todo)]
 
-use fnct::{backend::AsyncRedisBackend, format::PostcardFormatter, AsyncCache};
-use redis::aio::ConnectionManager;
-
 pub mod api;
 pub mod config;
 pub mod environments;
@@ -12,5 +9,3 @@ pub mod program;
 pub mod sandbox;
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub type Cache = AsyncCache<AsyncRedisBackend<ConnectionManager>, PostcardFormatter>;


### PR DESCRIPTION
Redis was only used to cache the base resource usage benchmark results, which are now stored in-memory.